### PR TITLE
Changed cli to reflect new events schema

### DIFF
--- a/blockade/libs/events.py
+++ b/blockade/libs/events.py
@@ -22,13 +22,9 @@ class EventsClient(Client):
 
         output = {'message': ""}
         for event in response['events']:
-            event['url'] = event['metadata']['url']
-            event['method'] = event['metadata']['method']
-            event['type'] = event['metadata']['type']
-
-            desc = "Source IP: {sourceIp}\n"
-            desc += "Datetime: {analysisTime}\n"
-            desc += "Indicator: {indicatorMatch}\n"
+            desc = "Source IP: {ip}\n"
+            desc += "Datetime: {time}\n"
+            desc += "Indicator: {match}\n"
             desc += "Method: {method}\n"
             desc += "URL: {url}\n"
             desc += "Request Type: {type}\n"


### PR DESCRIPTION
I am running the cloud_node synced to the master branch and it seems the schema for events has changed, which is raising some issues when the client from the analyst_toolbench is trying to parse out the results as the "metadata" key does not exist anymore and others have been renamed.

This pull request should fix that.